### PR TITLE
Added upcoming results; removed unused variables

### DIFF
--- a/main.py
+++ b/main.py
@@ -39,6 +39,11 @@ async def VLR_stats(region):
 async def VLR_ranks(region):
     return vlr.vlr_rankings(region)
 
+@limits(calls=50, period=TEN_MINUTES)
+@app.get("/match/upcoming")
+async def VLR_upcoming():
+    return vlr.vlr_upcoming()
+
 
 if __name__ == "__main__":
     uvicorn.run("main:app", host="0.0.0.0", port=3001)


### PR DESCRIPTION
I've added upcoming results as an API call, mostly off of your existing 'scores' function in scrape.py

Please note (and change as you see fit): to see upcoming vlr.gg matches, the address is "https://vlr.gg/matches". However, to make it more distinct from the already completed matches, I made the path "\<host\>/matches/upcoming", as 'upcoming' and 'results' are clearly referring to different time frames. Again, you're most welcome to modify or ask me to modify this.