### PR TITLE
Add timestamp to upcoming matches

### DIFF
--- a/main.py
+++ b/main.py
@@ -85,6 +85,10 @@ async def VLR_ranks(region, request: Request):
 async def VLR_upcoming(request: Request):
     return vlr.vlr_upcoming()
 
+@app.get("/match/upcoming_index")
+@limiter.limit("250/minute")
+async def VLR_upcoming_index(request: Request):
+    return vlr.vlr_upcoming_index()
 
 @app.get('/health')
 def health():


### PR DESCRIPTION
Hello there! Sadly this PR does not use the same page as the current one, that's why I created a whole new method to add the timestamp. I do think that this need a little more discussion, so I am open to any criticism or useful comment. I tried to add all the keys that were used on the current one but sadly there is no way to get the `tournament_icon`.

Timestamps are very useful when trying to use it on different locations, so I hope, if not this, some other workaround to get the timestamp gets implemented.