### PR TITLE
Added vlr_live_score() method

### DIFF
--- a/main.py
+++ b/main.py
@@ -90,6 +90,11 @@ async def VLR_upcoming(request: Request):
 async def VLR_upcoming_index(request: Request):
     return vlr.vlr_upcoming_index()
 
+@app.get("/match/live_score")
+@limiter.limit("250/minute")
+async def VLR_live_score(request: Request):
+    return vlr.vlr_live_score()
+
 @app.get('/health')
 def health():
     return "Healthy: OK"


### PR DESCRIPTION
Summary of Changes:

This PR adds a new vlr_live_score function in the codebase to fetch and process live game results and current rounds simultaneously. It extends the vlr_upcoming_index function and allows you to see round results. e.g. 3-12, 6-6, N/A, N/A (when rounds are not available).

Details of Changes:

Modified the code to select only the first item from the list of elements retrieved by html.css(".js-home-matches-upcoming a.wf-module-item").
Added logic to handle the case where there is no "h-match-team-rounds" element for a team. In such cases, the string "N/A" is appended to the rounds list.
Added a new rounds list, that stores the parsed result and is appended to result with "round1" and "round2".

Reason for Changes:

This change was made to see more information about live matches and can be used in Esports widgets and Tracking applications.

Testing:

**This code has not been tested and must be reviewed before the PR is approved.** Please leave feedback if there are any issues.