### PR TITLE
Fix `upcoming_matches` incorrect `url_path`

### DIFF
--- a/api/scrape.py
+++ b/api/scrape.py
@@ -300,7 +300,7 @@ class Vlr:
                     int(item.css_first(".moment-tz-convert").attributes["data-utc-ts"]),
                     tz=timezone.utc,
                 ).strftime("%Y-%m-%d %H:%M:%S")
-                url_path = "https://www.vlr.gg" + item.attributes["href"]
+                url_path = "https://www.vlr.gg/" + item.attributes["href"]
 
                 result.append(
                     {


### PR DESCRIPTION
The URL was missing a `/` which would lead it an incorrect page.

There's some stuff in the code that I'm not sure are intended. I'm not sure about it so mentioning before making a PR.

### Different link formats
In `upcoming_matches` the link is with the vlr.gg link while in `news` the link is without vlr.gg so I have to add it myself. The news one is labled as "url_path" instead of "news_page" but it is something I need to be aware of.
<img width="601" alt="image" src="https://github.com/axsddlr/vlrggapi/assets/100310118/70834efe-e6df-4761-a43c-b851abe8db8e">
News

<img width="785" alt="image" src="https://github.com/axsddlr/vlrggapi/assets/100310118/e5256cc8-8af9-4c96-93bf-b3798064d05d">
Upcoming matches

### Swapped tournament name and round info
Another one is `tournament_name` and `round_info` being swapped (which if I'm not wrong, I think the website has classes incorrect too). But it's another thing I need to be aware of because I'm expecting `tournament_name` to show the tournament name 
<img width="405" alt="image" src="https://github.com/axsddlr/vlrggapi/assets/100310118/68113f74-e78d-4ab1-926d-4d9c4fe1d91a">
Results (Correct)

<img width="469" alt="image" src="https://github.com/axsddlr/vlrggapi/assets/100310118/5ad16e4c-bc20-4114-80b1-def2c9802eb1">

Upcoming (Incorrect)

### Tournament Icon missing
The tournament icon is also missing. 
![image](https://github.com/axsddlr/vlrggapi/assets/100310118/4c2eeb87-7f60-45a2-9b25-be54bacf76b6)
In `README`

![image](https://github.com/axsddlr/vlrggapi/assets/100310118/747c9430-f22c-40c9-a45a-0c110ef306d2)
Missing in fetched data