### PR TITLE
Remove space in front of round names

### DIFF
--- a/api/scrape.py
+++ b/api/scrape.py
@@ -142,7 +142,7 @@ class Vlr:
 
             rounds = item.css_first("div.match-item-event-series").text()
             rounds = rounds.replace("\u2013", "-")
-            rounds = rounds.replace("\n", " ").replace("\t", "")
+            rounds = rounds.replace("\n", "").replace("\t", "")
 
             tourney = item.css_first("div.match-item-event").text()
             tourney = tourney.replace("\t", " ")


### PR DESCRIPTION
### Before
<img width="355" alt="image" src="https://github.com/user-attachments/assets/08ecd16b-157a-46d2-983c-8a390fb390d9">

### After
<img width="345" alt="image" src="https://github.com/user-attachments/assets/fbd24c9d-5dfa-48ae-9ac5-4d0ea36729eb">
